### PR TITLE
Fix alpha not resetting after canceling edit mode of QMesh

### DIFF
--- a/project/addons/quarkphysics/qmesh_editor_plugin.gd
+++ b/project/addons/quarkphysics/qmesh_editor_plugin.gd
@@ -21,6 +21,9 @@ var PARTICLE_INTERNAL=Color.DARK_SEA_GREEN
 
 	
 func _edit(object: Object) -> void:
+	if object == null and meshNode is QMeshNode:
+		meshNode.modulate.a = 1.0
+
 	meshNode=object
 	update_overlays()
 	if object is QMeshNode :
@@ -54,6 +57,7 @@ func _forward_canvas_draw_over_viewport(overlay: Control) -> void:
 		return
 		
 	if edit_mode==false:
+		meshNode.modulate.a = 1.0
 		return
 		
 	var screen_rect=overlay.get_rect()


### PR DESCRIPTION
Believe this should fix: https://github.com/erayzesen/godot-quarkphysics/issues/21

After:

[Screencast_20250117_190408.webm](https://github.com/user-attachments/assets/9a89153c-6a47-4ea0-b304-f62bfd1a3a63)

This was tested with 1.0.1. Could not test on master as it was spamming error when clicking on Edit QMesh button, should this be reported or already a known error?
