### PR TITLE
QPlatformerBody: Add the Collision Response to Soft Bodies 

### DIFF
--- a/src/QuarkPhysics/extensions/qplatformerbody.cpp
+++ b/src/QuarkPhysics/extensions/qplatformerbody.cpp
@@ -476,7 +476,7 @@ void QPlatformerBody::PostUpdate()
 	//Checking Floor
 	onFloor=false;
 
-	AddPosition(dirFloor*1.0f);
+	AddPosition(dirFloor*1.0);
 	vector<QManifold>  nextFloorManifolds=world->TestCollisionWithWorld(this);
 	SetPosition(tempPosition);
 
@@ -500,6 +500,11 @@ void QPlatformerBody::PostUpdate()
 			
 			float floorAngle=QVector::AngleBetweenTwoVectors(normal,upDirection);
 			if( abs(floorAngle)<maxFloorAngle ){
+				//For soft body vertical collision responses
+				if (collidedBody->GetBodyType()==QBody::BodyTypes::SOFT){
+					AddPosition(dirFloor*1.0);
+					manifold.Solve();
+				}
 				onFloor=true;
 				if(collidedBody->GetBodyType()==QBody::BodyTypes::RIGID){
 					QRigidBody *collidedRigidBody=static_cast<QRigidBody*>(collidedBody);

--- a/src/QuarkPhysics/qcollision.cpp
+++ b/src/QuarkPhysics/qcollision.cpp
@@ -594,6 +594,7 @@ void QCollision::CircleAndCircle(vector<QParticle*> &particlesA,vector<QParticle
 				//normal=distVec.Normalized();
 				//The normal with previous positions gives us more realistic collision normals in the simulation.
 				normal=(pB->GetPreviousGlobalPosition()-pA->GetPreviousGlobalPosition()).Normalized();
+				//normal=(pB->GetGlobalPosition()-pA->GetGlobalPosition()).Normalized();
 
 				penetration=totalRadius-positionalPenetration;
 

--- a/src/QuarkPhysics/qmanifold.cpp
+++ b/src/QuarkPhysics/qmanifold.cpp
@@ -229,28 +229,6 @@ void QManifold::Solve()
 		if(cancelSolving==true)
 			continue;
 
-
-		//Exceptions of Disabled Particles
-		if(contact->particle->GetEnabled()==false  )
-			continue;
-
-		for (size_t n=0;n<contact->referenceParticles.size();++n ){
-			if (contact->referenceParticles[n]->GetEnabled()==false ){
-				cancelSolving=true;
-				break;
-			}
-				
-		}
-
-		if(cancelSolving==true)
-			continue;
-
-
-
-		
-
-		
-
 		//Exceptions of Lazy Particles
 		bool incidentParticleIsLazy=false;
 		bool referenceParticlesAreLazy=false;
@@ -286,7 +264,24 @@ void QManifold::Solve()
 		if(cancelSolving==true)
 			continue;
 
-		
+
+		//Exceptions of Disabled Particles
+		if(contact->particle->GetEnabled()==false  )
+			continue;
+
+		for (size_t n=0;n<contact->referenceParticles.size();++n ){
+			if (contact->referenceParticles[n]->GetEnabled()==false ){
+				cancelSolving=true;
+				break;
+			}
+				
+		}
+
+		if(cancelSolving==true)
+			continue;
+
+
+
 
 
 


### PR DESCRIPTION
The `QPlatformerBody` object contains custom solutions that also benefit from more traditional approaches within the physics engine. It has vertical and horizontal velocities. These solutions provide good stability for rigid bodies, but interactions on the vertical axis are limited for a soft body object. When a platformer character steps onto a soft body, you would want interactions to occur with the soft object.

This PR ensures that `QPlatformerBody` reasonably supports the expected vertical-axis interactions with `QSoftBody` objects.