### PR TITLE
Add the Distance Limit Feature to Spring Objects

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ jobs:
             float-precision: single
             arch: x86_64
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             
 
           - platform: windows
@@ -47,28 +47,28 @@ jobs:
             float-precision: single
             arch: arm64
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             
 
           - platform: android
             float-precision: single
             arch: arm32
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             
 
           - platform: android
             float-precision: single
             arch: x86_64
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             
 
           - platform: android
             float-precision: single
             arch: x86_32
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             
 
           - platform: ios
@@ -82,7 +82,7 @@ jobs:
             float-precision: single
             arch: wasm32
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             threads: yes
             
           
@@ -90,7 +90,7 @@ jobs:
             float-precision: single
             arch: wasm32
             target-type: template_debug
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             threads: no
             
 
@@ -99,7 +99,7 @@ jobs:
             float-precision: single
             arch: x86_64
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             
 
           - platform: windows
@@ -124,25 +124,25 @@ jobs:
             float-precision: single
             arch: arm64
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - platform: android
             float-precision: single
             arch: arm32
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - platform: android
             float-precision: single
             arch: x86_64
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - platform: android
             float-precision: single
             arch: x86_32
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - platform: ios
             float-precision: single
@@ -154,14 +154,14 @@ jobs:
             float-precision: single
             arch: wasm32
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             threads: yes
 
           - platform: web
             float-precision: single
             arch: wasm32
             target-type: template_release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             threads: no
 
         # Double precision templates
@@ -170,7 +170,7 @@ jobs:
           #   float-precision: double
           #   arch: x86_64
           #   target-type: template_debug
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
             
 
           # - platform: windows
@@ -198,28 +198,28 @@ jobs:
           #   float-precision: double
           #   arch: arm64
           #   target-type: template_debug
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
             
 
           # - platform: android
           #   float-precision: double
           #   arch: arm32
           #   target-type: template_debug
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
             
 
           # - platform: android
           #   float-precision: double
           #   arch: x86_64
           #   target-type: template_debug
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
             
 
           # - platform: android
           #   float-precision: double
           #   arch: x86_32
           #   target-type: template_debug
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
             
 
           # - platform: ios
@@ -233,7 +233,7 @@ jobs:
           #   float-precision: double
           #   arch: wasm32
           #   target-type: template_debug
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
             
 
         # Double precision release templates
@@ -241,7 +241,7 @@ jobs:
           #   float-precision: double
           #   arch: x86_64
           #   target-type: template_release
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
 
           # - platform: windows
           #   float-precision: double
@@ -265,25 +265,25 @@ jobs:
           #   float-precision: double
           #   arch: arm64
           #   target-type: template_release
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
 
           # - platform: android
           #   float-precision: double
           #   arch: arm32
           #   target-type: template_release
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
 
           # - platform: android
           #   float-precision: double
           #   arch: x86_64
           #   target-type: template_release
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
 
           # - platform: android
           #   float-precision: double
           #   arch: x86_32
           #   target-type: template_release
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
 
           # - platform: ios
           #   float-precision: double
@@ -295,7 +295,7 @@ jobs:
           #   float-precision: double
           #   arch: wasm32
           #   target-type: template_release
-          #   os: ubuntu-20.04
+          #   os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -373,7 +373,7 @@ jobs:
   # Merges all the build artifacts together into a single godot-cpp-template artifact.
   # If you comment out this step, all the builds will be uploaded individually.
   merge:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Merge Artifacts
@@ -384,7 +384,7 @@ jobs:
           delete-merged: true
 
   package:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       needs: merge
       steps:
         - name: Checkout

--- a/project/examples/5_so_soft_world/main.tscn
+++ b/project/examples/5_so_soft_world/main.tscn
@@ -3,7 +3,7 @@
 [node name="Node2D" type="Node2D"]
 
 [node name="QWorldNode" type="QWorldNode" parent="."]
-iteration_count = 8
+iteration_count = 2
 time_scale = 0.5
 debug_renderer = false
 enable_debug_mouse_interactions = true

--- a/src/QuarkPhysics/qspring.cpp
+++ b/src/QuarkPhysics/qspring.cpp
@@ -144,9 +144,12 @@ void QSpring::Update(float rigidity,bool internalsException, bool isWorldSpring)
 		float k=0.5f;
 		if(particleACanGetResponse==false || particleBCanGetResponse==false)
 			k=1.0f;
-		float lengthRate=sl/length;
-		if( lengthRate>4.0f || lengthRate<0.25f ){
-			rigidity=1.0f;
+		
+		if (enableDistanceLimit){
+			float lengthRate=sl/length;
+			if( lengthRate>maximumDistanceFactor || lengthRate<minimumDistanceFactor ){
+				rigidity=1.0f;
+			} 
 		}
 		forceA*=k*rigidity;
 		forceB*=k*rigidity;

--- a/src/QuarkPhysics/qspring.h
+++ b/src/QuarkPhysics/qspring.h
@@ -42,6 +42,9 @@ class QSpring
 	QParticle *pB;
 	float length;
 	bool isInternal=false;
+	bool enableDistanceLimit=false;
+	float minimumDistanceFactor=0.25f;
+	float maximumDistanceFactor=4.0f;
 	bool enabled=true;
 public:
 	/**
@@ -91,10 +94,29 @@ public:
 	float GetRigidity(){
 		return rigidity;
 	}
+
+	/** Returns whether the distance limit is enabled.
+	 *  If enabled, the spring applies full-strength constraints when the distance between particles
+	 *  becomes smaller or larger than the allowed range defined by the minimum and maximum distance factors.
+	 */
+	bool GetDistanceLimitEnabled(){
+		return enableDistanceLimit;
+	}
+	/**  Returns the minimum distance factor to be enforced when the distance limits feature is enabled. */
+	float GetMinimumDistanceFactor(){
+		return minimumDistanceFactor;
+	}
+	/**  Returns the maximum distance factor to be enforced when the distance limits feature is enabled. */
+	float GetMaximumDistanceFactor(){
+		return minimumDistanceFactor;
+	}
+
 	/** Returns whether the spring is enabled. */
 	bool GetEnabled(){
 		return enabled;
 	}
+
+	
 
 	//Set Methods
 	/** Sets particleA of the spring.
@@ -137,6 +159,26 @@ public:
 		this->rigidity=rigidity;
 		return this;
 	}
+
+	/** Sets whether the distance limit is enabled.
+	 *  If enabled, the spring applies full-strength constraints when the distance between particles
+	 *  becomes smaller or larger than the allowed range defined by the minimum and maximum distance factors.
+	 */
+	QSpring *SetDistanceLimitEnabled(bool value){
+		enableDistanceLimit=value;
+		return this;
+	}
+	/**  Sets the minimum distance factor to be enforced when the distance limits feature is enabled. */
+	QSpring *SetMinimumDistanceFactor(float value){
+		minimumDistanceFactor=value;
+		return this;
+	}
+	/**  Sets the maximum distance factor to be enforced when the distance limits feature is enabled. */
+	QSpring *SetMaximumDistanceFactor(float value){
+		maximumDistanceFactor=value;
+		return this;
+	}
+
 	/** Sets whether the spring is enabled. 
 	 * @param value True or false.
 	 * @return A pointer to the spring itself.

--- a/src/qspring_object.cpp
+++ b/src/qspring_object.cpp
@@ -9,6 +9,9 @@ void QSpringObject::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_length"),&QSpringObject::get_length );
     ClassDB::bind_method(D_METHOD("get_is_internal"),&QSpringObject::get_is_internal );
     ClassDB::bind_method(D_METHOD("get_rigidity"),&QSpringObject::get_rigidity );
+    ClassDB::bind_method(D_METHOD("get_distance_limit_enabled"),&QSpringObject::get_distance_limit_enabled );
+    ClassDB::bind_method(D_METHOD("get_minimum_distance_factor"),&QSpringObject::get_minimum_distance_factor );
+    ClassDB::bind_method(D_METHOD("get_maximum_distance_factor"),&QSpringObject::get_maximum_distance_factor );
     ClassDB::bind_method(D_METHOD("get_enabled"),&QSpringObject::get_enabled );
     //set
     ClassDB::bind_method(D_METHOD("set_particle_a","particle_object"),&QSpringObject::set_particle_a );
@@ -16,6 +19,9 @@ void QSpringObject::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_length","value"),&QSpringObject::set_length );
     ClassDB::bind_method(D_METHOD("set_is_internal","value"),&QSpringObject::set_is_internal );
     ClassDB::bind_method(D_METHOD("set_rigidity","value"),&QSpringObject::set_rigidity );
+    ClassDB::bind_method(D_METHOD("set_distance_limit_enabled","value"),&QSpringObject::set_distance_limit_enabled );
+    ClassDB::bind_method(D_METHOD("set_minimum_distance_factor","value"),&QSpringObject::set_minimum_distance_factor );
+    ClassDB::bind_method(D_METHOD("set_maximum_distance_factor","value"),&QSpringObject::set_maximum_distance_factor );
     ClassDB::bind_method(D_METHOD("set_enabled","value"),&QSpringObject::set_enabled );
 
     ClassDB::bind_method(D_METHOD("configure","particle_object_a","particle_object_b","length","internal"),&QSpringObject::configure );
@@ -42,6 +48,21 @@ bool QSpringObject::get_is_internal(){
 
 float QSpringObject::get_rigidity() {
 	return springObject->GetRigidity();
+}
+
+bool QSpringObject::get_distance_limit_enabled()
+{
+    return springObject->GetDistanceLimitEnabled();
+}
+
+float QSpringObject::get_minimum_distance_factor()
+{
+    return springObject->GetMinimumDistanceFactor();
+}
+
+float QSpringObject::get_maximum_distance_factor()
+{
+    return springObject->GetMaximumDistanceFactor();
 }
 
 bool QSpringObject::get_enabled() {
@@ -80,6 +101,24 @@ Ref<QSpringObject> QSpringObject::set_is_internal(bool value) {
 Ref<QSpringObject> QSpringObject::set_rigidity(float value) {
 	springObject->SetRigidity(value);
 	return Ref<QSpringObject>(this);
+}
+
+Ref<QSpringObject> QSpringObject::set_distance_limit_enabled(bool value)
+{
+    springObject->SetDistanceLimitEnabled(value);
+    return Ref<QSpringObject>(this);
+}
+
+Ref<QSpringObject> QSpringObject::set_minimum_distance_factor(float value)
+{
+    springObject->SetMinimumDistanceFactor(value);
+    return Ref<QSpringObject>(this);
+}
+
+Ref<QSpringObject> QSpringObject::set_maximum_distance_factor(float value)
+{
+    springObject->SetMaximumDistanceFactor(value);
+    return Ref<QSpringObject>(this);
 }
 
 Ref<QSpringObject> QSpringObject::set_enabled(bool value) {

--- a/src/qspring_object.h
+++ b/src/qspring_object.h
@@ -100,6 +100,9 @@ public:
     float get_length();
     bool get_is_internal();
     float get_rigidity();
+    bool get_distance_limit_enabled();
+    float get_minimum_distance_factor();
+    float get_maximum_distance_factor();
     bool get_enabled();
 
     //Set Methods
@@ -108,6 +111,9 @@ public:
     Ref<QSpringObject> set_length(float value);
     Ref<QSpringObject> set_is_internal(bool value);
     Ref<QSpringObject> set_rigidity(float value);
+    Ref<QSpringObject> set_distance_limit_enabled(bool value);
+    Ref<QSpringObject> set_minimum_distance_factor(float value);
+    Ref<QSpringObject> set_maximum_distance_factor(float value);
     Ref<QSpringObject> set_enabled(bool value);
 
     friend class QMeshNode;


### PR DESCRIPTION
This PR adds an optional distance limit feature to spring objects.

In certain soft body objects where stiffness is set to extremely low values, distance constraints applied via springs can cause energy spikes in the simulation, potentially destabilizing it.

To prevent this, minimum and maximum multipliers of the target rest distance can be defined as hard limits that the spring should not exceed.

As part of this change, 3 getter and 3 setter methods have been added to the QSpringObject class:

```gdscript
bool get_distance_limit_enabled();
float get_minimum_distance_factor();
float get_maximum_distance_factor();

set_distance_limit_enabled(value:bool)
set_minimum_distance_factor(value:float)
set_maximum_distance_factor(value:float)
```


