### PR TITLE
Add get_average_position() and get_average_rotation() methods to QMeshNode 

### DIFF
--- a/src/QuarkPhysics/qmesh.cpp
+++ b/src/QuarkPhysics/qmesh.cpp
@@ -144,6 +144,27 @@ QParticle *QMesh::GetParticleAt(int index){
 
 //Polygons
 
+QVector QMesh::GetAveragePosition()
+{
+    if(particles.size()==1)
+		return particles[0]->GetGlobalPosition();
+	//Finding Actual Position
+	QVector averagePosition=QVector::Zero();
+	
+	for(int i=0;i<particles.size();i++){
+		QParticle *particle=particles[i];
+		averagePosition+=particle->GetGlobalPosition();
+	}  
+	averagePosition/=particles.size();
+
+	return averagePosition;
+}
+
+float QMesh::GetAverageRotation()
+{
+	return GetAveragePositionAndRotation(particles).second;
+}
+
 QMesh *QMesh::SetPolygon(vector<QParticle *> polygonParticles)
 {
 	polygon=polygonParticles;

--- a/src/QuarkPhysics/qmesh.h
+++ b/src/QuarkPhysics/qmesh.h
@@ -330,6 +330,13 @@ public:
 		}
 		return -1;
 	}
+	/** Returns the averaged position calculated from the global positions of the particles of the mesh.
+	 */
+	QVector GetAveragePosition();
+
+	/** Returns the average rotation angle in radians, computed by comparing the current global positions of the moving particles to their initial positions.
+	 */
+	float GetAverageRotation();
 
 
 

--- a/src/qmesh_node.cpp
+++ b/src/qmesh_node.cpp
@@ -924,6 +924,8 @@ void QMeshNode::_bind_methods()
     ClassDB::bind_method(D_METHOD("get_particle_at","index"),&QMeshNode::get_particle_at );
     ClassDB::bind_method(D_METHOD("get_particle_count"),&QMeshNode::get_particle_count );
     ClassDB::bind_method(D_METHOD("get_particle_index","particle_object"),&QMeshNode::get_particle_index );
+    ClassDB::bind_method(D_METHOD("get_average_position"),&QMeshNode::get_average_position );
+    ClassDB::bind_method(D_METHOD("get_average_rotation"),&QMeshNode::get_average_rotation );
     ClassDB::bind_method(D_METHOD("get_average_position_and_rotation","particle_collection"),&QMeshNode::get_average_position_and_rotation );
     ClassDB::bind_method(D_METHOD("get_matching_particle_positions","particle_collection","target_position","target_rotation"),&QMeshNode::get_matching_particle_positions );
 
@@ -1169,6 +1171,17 @@ bool QMeshNode::get_show_polygon_enabled() {
 bool QMeshNode::get_show_particle_index_numbers_enabled()
 {
     return showParticleIndexNumbers;
+}
+
+Vector2 QMeshNode::get_average_position()
+{
+    QVector res=meshObject->GetAveragePosition();
+    return Vector2(res.x,res.y);
+}
+
+float QMeshNode::get_average_rotation()
+{
+    return meshObject->GetAverageRotation();
 }
 
 Array QMeshNode::get_average_position_and_rotation(TypedArray<QParticleObject> particle_collection) {

--- a/src/qmesh_node.h
+++ b/src/qmesh_node.h
@@ -172,6 +172,8 @@ public:
     bool get_show_springs_enabled();
     bool get_show_polygon_enabled();
     bool get_show_particle_index_numbers_enabled();
+    Vector2 get_average_position();
+    float get_average_rotation();
     Array get_average_position_and_rotation(TypedArray<QParticleObject> particle_collection);
     Array get_matching_particle_positions(TypedArray<QParticleObject> particle_collection,Vector2 target_position,float target_rotation);
     float get_min_angle_constraint_of_polygon();


### PR DESCRIPTION
In the Godot extension of QuarkPhysics, we had previously added the method `get_average_position_and_rotation(particle_collection)`, which is originally a static method in the core QuarkPhysics library. This method returns a pair: the first element is the average position, and the second is the average rotation in radians of the given particle collection.

While this method technically works in the extension by returning a two-element array, it introduces some practical issues in usage:

1- The method is designed as static, but Godot’s GDExtension system does not support binding static methods directly.

2-  It requires passing in a particle collection as an argument. In most real-world scenarios, this collection is simply the internal particle list of a given QMeshNode. Asking users to manually extract or construct this collection in GDScript introduces unnecessary complexity and potential performance overhead.

To address these issues, we now provide two instance methods on QMeshNode:

* `QMeshNode.get_average_position()`

* `QMeshNode.get_average_rotation()`

These methods operate directly on the node's own particles and return the respective values without requiring any extra input or processing. They have also been added to the local C++ API.

With this change, users can now easily and efficiently retrieve the average position and rotation of any mesh node’s particles, with minimal effort and maximum clarity.
