### PR TITLE
Fix the Hot Collision Solvers Issue in Collision Tests

### DIFF
--- a/src/QuarkPhysics/extensions/qplatformerbody.cpp
+++ b/src/QuarkPhysics/extensions/qplatformerbody.cpp
@@ -430,7 +430,7 @@ void QPlatformerBody::PostUpdate()
 
 		tempPosition=GetPosition();
 		AddPosition(dirFloor*movingFloorSnapOffset);
-		vector<QCollision::Contact*> contacts= world->GetCollisions(this,lastMovableFloor);
+		vector<QCollision::Contact*> contacts= world->GetCollisions(this,lastMovableFloor,false);
 		SetPosition(tempPosition);
 
 		if(contacts.size()==0 ){

--- a/src/QuarkPhysics/qworld.cpp
+++ b/src/QuarkPhysics/qworld.cpp
@@ -635,7 +635,7 @@ vector<QManifold> QWorld::TestCollisionWithWorld(QBody *body)
 						mesh->UpdatePolygonBisectors();
 					}
 
-					vector<QCollision::Contact*> contacts=GetCollisions(body,otherBody);
+					vector<QCollision::Contact*> contacts=GetCollisions(body,otherBody,false);
 					if(contacts.size()>0){
 						QManifold manifold(body,otherBody);
 						manifold.contacts=contacts;
@@ -924,7 +924,7 @@ bool QWorld::CheckCollisionException(QBody *bodyA, QBody *bodyB)
 
 
 //Collision Constraints and Response Between Bodies
-vector<QCollision::Contact*> QWorld::GetCollisions(QBody *bodyA, QBody *bodyB){
+vector<QCollision::Contact*> QWorld::GetCollisions(QBody *bodyA, QBody *bodyB,bool applyHotSolvers){
 	vector<QCollision::Contact*> contactList;
 
 	vector<QMesh*>* meshesA=bodyA->GetMeshes();
@@ -1014,11 +1014,15 @@ vector<QCollision::Contact*> QWorld::GetCollisions(QBody *bodyA, QBody *bodyB){
 					QCollision::CircleAndPolygon(polygonMesh->polygon,polylineMesh->polygon,contactList);
 				}else{
 					vector<QCollision::Contact*> hotContactList;
-					QManifold hotManifold(bodyA,bodyB);
-					QCollision::CircleAndPolygon(polylineMesh->polygon,polygonMesh->polygon,hotContactList);
-					hotManifold.contacts=hotContactList;
-					hotManifold.Solve();
-					hotManifold.SolveFrictionAndVelocities();
+					if (applyHotSolvers){
+						QManifold hotManifold(bodyA,bodyB);
+						QCollision::CircleAndPolygon(polylineMesh->polygon,polygonMesh->polygon,hotContactList);
+						hotManifold.contacts=hotContactList;
+						hotManifold.Solve();
+						hotManifold.SolveFrictionAndVelocities();
+					}else{
+						QCollision::CircleAndPolygon(polylineMesh->polygon,polygonMesh->polygon,contactList);
+					}
 					
 					QCollision::PolylineAndPolygon(polylineMesh->polygon,polygonMesh->polygon,contactList);
 					

--- a/src/QuarkPhysics/qworld.h
+++ b/src/QuarkPhysics/qworld.h
@@ -280,7 +280,7 @@ public:
 	 * @param bodyA A body in the world.
 	 * @param bodyB Another body in the world.
 	 */
-	static vector<QCollision::Contact*> GetCollisions(QBody *bodyA, QBody *bodyB);
+	static vector<QCollision::Contact*> GetCollisions(QBody *bodyA, QBody *bodyB,bool applyHotSolvers=true);
 
 
 	/**Adds a body to the world


### PR DESCRIPTION
In queries made solely for collision testing purposes, the hot collision solvers—originally added for exceptional collision comparisons—are also being applied by default. When only a collision query is performed, there should be no intervention in the simulation and no collision resolution should be applied. This PR fixes that issue.
